### PR TITLE
URL Saving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2522,6 +2522,7 @@ dependencies = [
  "native-windows-gui",
  "reqwest",
  "serde",
+ "serde_json",
  "thiserror",
  "tokio",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2511,7 +2511,7 @@ dependencies = [
 
 [[package]]
 name = "pocket-relay-client"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "blaze-pk",
  "blaze-ssl-async",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ native = ["dep:native-windows-gui"]
 # Serialization and HTTP requests
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 # Blaze packet system 
 blaze-pk = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pocket-relay-client"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 build = "build.rs"
 license = "MIT"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -24,3 +24,6 @@ pub const MAIN_PORT: u16 = 42128;
 pub const TELEMETRY_PORT: u16 = 42129;
 /// The local quality of service server port
 pub const QOS_PORT: u16 = 42130;
+
+/// Name of the file that stores saved pocket relay configuration info
+pub const CONFIG_FILE_NAME: &str = "pocket-relay-client.json";

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 use constants::*;
 use native_dialog::{FileDialog, MessageDialog};
 use serde::{Deserialize, Serialize};
-use std::env::current_dir;
+use std::env::{current_dir, current_exe};
 use std::fs::{copy, read, remove_file, write};
 use std::string::FromUtf8Error;
 use std::{
@@ -12,6 +12,7 @@ use std::{
 };
 use thiserror::Error;
 use tokio::sync::RwLock;
+use tokio::task::spawn_blocking;
 
 mod constants;
 mod servers;
@@ -48,30 +49,55 @@ pub struct ClientConfig {
     pub connection_url: String,
 }
 
-pub fn read_config_file() -> Option<ClientConfig> {
-    let current_path = current_dir().unwrap();
-    let file_path = current_path.join(CONFIG_FILE_NAME);
+fn read_config_file() -> Option<ClientConfig> {
+    let current_path = current_exe().unwrap();
+    let parent = current_path
+        .parent()
+        .expect("Missing parent directory to current exe path");
+
+    let file_path = parent.join(CONFIG_FILE_NAME);
     if !file_path.exists() {
         return None;
     }
 
     let bytes = match read(file_path) {
         Ok(value) => value,
-        Err(err) => return None,
+        Err(err) => {
+            show_error("Failed to read client config", &err.to_string());
+            return None;
+        }
     };
 
     let config: ClientConfig = match serde_json::from_slice(&bytes) {
         Ok(value) => value,
         Err(err) => {
-            show_error(
-                "Failed to parse client config",
-                "Client configuration failed to be parsed, it will be ignored",
-            );
+            show_error("Failed to parse client config", &err.to_string());
             return None;
         }
     };
 
     Some(config)
+}
+
+fn write_config_file(config: &ClientConfig) {
+    let current_path = current_exe().unwrap();
+    let parent = current_path
+        .parent()
+        .expect("Missing parent directory to current exe path");
+
+    let file_path = parent.join(CONFIG_FILE_NAME);
+
+    let bytes = match serde_json::to_vec(config) {
+        Ok(value) => value,
+        Err(err) => {
+            show_error("Failed to save client config", &err.to_string());
+            return;
+        }
+    };
+
+    if let Err(err) = write(file_path, bytes) {
+        show_error("Failed to save client config", &err.to_string());
+    }
 }
 
 /// Shared target location
@@ -251,10 +277,21 @@ enum LookupError {
 /// target before returning the result
 ///
 /// `target` The target to use
-async fn try_update_host(target: String) -> Result<LookupData, LookupError> {
-    let result = try_lookup_host(target).await?;
+async fn try_update_host(target: String, persist: bool) -> Result<LookupData, LookupError> {
+    let result = try_lookup_host(&target).await?;
     let mut write = TARGET.write().await;
     *write = Some(result.clone());
+
+    // Write the config file with the new connection URL
+    if persist {
+        _ = spawn_blocking(move || {
+            write_config_file(&ClientConfig {
+                connection_url: target,
+            })
+        })
+        .await;
+    }
+
     Ok(result)
 }
 
@@ -264,15 +301,15 @@ async fn try_update_host(target: String) -> Result<LookupData, LookupError> {
 /// considered valid.
 ///
 /// `host` The host to try and lookup
-async fn try_lookup_host(host: String) -> Result<LookupData, LookupError> {
+async fn try_lookup_host(host: &str) -> Result<LookupData, LookupError> {
     let mut url = String::new();
 
     // Fill in missing host portion
     if !host.starts_with("http://") && !host.starts_with("https://") {
         url.push_str("http://");
-        url.push_str(&host)
+        url.push_str(host)
     } else {
-        url.push_str(&host);
+        url.push_str(host);
     }
 
     if !host.ends_with('/') {

--- a/src/ui/iced.rs
+++ b/src/ui/iced.rs
@@ -7,8 +7,8 @@ use iced::{
     executor,
     theme::Palette,
     widget::{
-        button, checkbox, column, container, row, text, text_input, Button, Checkbox, Column, Row,
-        Text, TextInput,
+        button, checkbox, column, container, row, text, text_input, Button, Column, Row, Text,
+        TextInput,
     },
     window::{self, icon},
     Application, Color, Command, Length, Settings, Theme,
@@ -124,7 +124,7 @@ impl Application for App {
                 };
 
                 // Perform the async lookup with the callback
-                return Command::perform(try_update_host(target), post_lookup);
+                return Command::perform(try_update_host(target, self.remember), post_lookup);
             }
             // Patching
             AppMessage::PatchGame => match try_patch_game() {

--- a/src/ui/native.rs
+++ b/src/ui/native.rs
@@ -2,7 +2,7 @@ use crate::{
     constants::{APP_VERSION, ICON_BYTES},
     remove_host_entry, try_patch_game, try_remove_patch, try_update_host, ClientConfig,
 };
-use ngw::{GridLayoutItem, Icon};
+use ngw::{CheckBoxState, GridLayoutItem, Icon};
 
 extern crate native_windows_gui as ngw;
 
@@ -12,9 +12,14 @@ pub fn init(runtime: tokio::runtime::Runtime, config: Option<ClientConfig>) {
     ngw::init().expect("Failed to initialize native UI");
     ngw::Font::set_global_family("Segoe UI").expect("Failed to set default font");
 
+    let (target, remember) = config
+        .map(|value| (value.connection_url, true))
+        .unwrap_or_default();
+
     let mut window = Default::default();
     let mut target_url = Default::default();
     let mut set_button = Default::default();
+    let mut remember_checkbox = Default::default();
     let mut p_button = Default::default();
     let mut pr_button = Default::default();
     let layout = Default::default();
@@ -64,7 +69,7 @@ pub fn init(runtime: tokio::runtime::Runtime, config: Option<ClientConfig>) {
 
     // Create the url input and set button
     ngw::TextInput::builder()
-        .text("")
+        .text(&target)
         .focus(true)
         .parent(&window)
         .build(&mut target_url)
@@ -73,6 +78,16 @@ pub fn init(runtime: tokio::runtime::Runtime, config: Option<ClientConfig>) {
         .text("Set")
         .parent(&window)
         .build(&mut set_button)
+        .unwrap();
+    ngw::CheckBox::builder()
+        .text("Save connection URL")
+        .check_state(if remember {
+            CheckBoxState::Checked
+        } else {
+            CheckBoxState::Unchecked
+        })
+        .parent(&window)
+        .build(&mut remember_checkbox)
         .unwrap();
 
     // Create the patch buttons
@@ -93,11 +108,12 @@ pub fn init(runtime: tokio::runtime::Runtime, config: Option<ClientConfig>) {
         .child_item(GridLayoutItem::new(&top_label, 0, 0, 2, 1))
         .child_item(GridLayoutItem::new(&target_url, 0, 1, 2, 1))
         .child_item(GridLayoutItem::new(&set_button, 0, 2, 2, 1))
-        .child_item(GridLayoutItem::new(&c_label, 0, 3, 2, 1))
-        .child_item(GridLayoutItem::new(&mid_label, 0, 4, 2, 1))
-        .child_item(GridLayoutItem::new(&p_button, 0, 5, 1, 1))
-        .child_item(GridLayoutItem::new(&pr_button, 1, 5, 1, 1))
-        .child_item(GridLayoutItem::new(&bot_label, 0, 6, 2, 1))
+        .child_item(GridLayoutItem::new(&remember_checkbox, 0, 3, 2, 1))
+        .child_item(GridLayoutItem::new(&c_label, 0, 4, 2, 1))
+        .child_item(GridLayoutItem::new(&mid_label, 0, 5, 2, 1))
+        .child_item(GridLayoutItem::new(&p_button, 0, 6, 1, 1))
+        .child_item(GridLayoutItem::new(&pr_button, 1, 6, 1, 1))
+        .child_item(GridLayoutItem::new(&bot_label, 0, 7, 2, 1))
         .build(&layout)
         .unwrap();
 
@@ -120,7 +136,10 @@ pub fn init(runtime: tokio::runtime::Runtime, config: Option<ClientConfig>) {
 
                     let target = target_url.text();
 
-                    let result = runtime.block_on(try_update_host(target));
+                    let result = runtime.block_on(try_update_host(
+                        target,
+                        remember_checkbox.check_state() == CheckBoxState::Checked,
+                    ));
 
                     match result {
                         Ok(value) => c_label.set_text(&format!(

--- a/src/ui/native.rs
+++ b/src/ui/native.rs
@@ -1,6 +1,6 @@
 use crate::{
     constants::{APP_VERSION, ICON_BYTES},
-    remove_host_entry, try_patch_game, try_remove_patch, try_update_host,
+    remove_host_entry, try_patch_game, try_remove_patch, try_update_host, ClientConfig,
 };
 use ngw::{GridLayoutItem, Icon};
 
@@ -8,7 +8,7 @@ extern crate native_windows_gui as ngw;
 
 pub const WINDOW_SIZE: (i32, i32) = (500, 300);
 
-pub fn init(runtime: tokio::runtime::Runtime) {
+pub fn init(runtime: tokio::runtime::Runtime, config: Option<ClientConfig>) {
     ngw::init().expect("Failed to initialize native UI");
     ngw::Font::set_global_family("Segoe UI").expect("Failed to set default font");
 


### PR DESCRIPTION
## Description

Adds a new URL saving system from #7 which adds a checkbox to both UI variants that will save the connection URL used for future launches 

## Changes
- Added "Save connection URL" button to native UI
- Added "Save connection URL" button to iced UI
- Implemented saving and loading for local config file
- Bumped version number for release

## Related Issues

Closes #7 

## Screenshots

![image](https://github.com/PocketRelay/Client/assets/33708767/50bcf69d-d8a0-44e5-90a5-9dfc232a6dfd)
![image](https://github.com/PocketRelay/Client/assets/33708767/89228362-317e-4cab-a426-7e96aa2aad16)