### PR TITLE
Client side HTTP proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2516,6 +2516,7 @@ dependencies = [
  "blaze-pk",
  "blaze-ssl-async",
  "futures-util",
+ "hyper",
  "iced",
  "local-ip-address",
  "native-dialog",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2511,7 +2511,7 @@ dependencies = [
 
 [[package]]
 name = "pocket-relay-client"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "blaze-pk",
  "blaze-ssl-async",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pocket-relay-client"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 build = "build.rs"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ tokio-util = { version = "0.7", features = ["codec"] }
 futures-util = { version = "0.3", features = ["sink"] }
 thiserror = "1"
 semver = "1.0.18"
+hyper = { version = "0.14", features = ["server", "http1", "tcp", "runtime"] }
 
 # Iced GUI framework variant
 [dependencies.iced]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -24,6 +24,8 @@ pub const MAIN_PORT: u16 = 42128;
 pub const TELEMETRY_PORT: u16 = 42129;
 /// The local quality of service server port
 pub const QOS_PORT: u16 = 42130;
+/// The local HTTP server port
+pub const HTTP_PORT: u16 = 42131;
 
 /// Name of the file that stores saved pocket relay configuration info
 pub const CONFIG_FILE_NAME: &str = "pocket-relay-client.json";

--- a/src/servers/http.rs
+++ b/src/servers/http.rs
@@ -1,8 +1,10 @@
+use crate::TARGET;
 use crate::{constants::HTTP_PORT, show_error};
 use hyper::body::Body;
 use hyper::service::service_fn;
-use hyper::Response;
 use hyper::{server::conn::Http, Request};
+use hyper::{Response, StatusCode};
+use reqwest::Client;
 use std::convert::Infallible;
 use std::{net::Ipv4Addr, process::exit};
 use tokio::net::TcpListener;
@@ -27,17 +29,70 @@ pub async fn start_server() {
 
         tokio::task::spawn(async move {
             if let Err(err) = Http::new()
-                .serve_connection(stream, service_fn(hello))
+                .serve_connection(stream, service_fn(proxy_http))
                 .await
             {
-                println!("Error serving connection: {:?}", err);
+                eprintln!("Failed to serve http connection: {:?}", err);
             }
         });
     }
 }
 
-// An async function that consumes a request, does nothing with it and returns a
-// response.
-async fn hello(req: Request<hyper::body::Body>) -> Result<Response<Body>, Infallible> {
-    Ok(Response::new(req.into_body()))
+async fn proxy_http(req: Request<hyper::body::Body>) -> Result<Response<Body>, Infallible> {
+    let path = req
+        .uri()
+        .path_and_query()
+        .map(|value| value.as_str())
+        .unwrap_or_default();
+
+    let target_url = {
+        let target_guard = TARGET.read().await;
+        let target = match target_guard.as_ref() {
+            Some(value) => value,
+            None => {
+                let mut error_response = Response::new(hyper::Body::empty());
+                *error_response.status_mut() = StatusCode::SERVICE_UNAVAILABLE;
+                return Ok(error_response);
+            }
+        };
+
+        format!(
+            "{}://{}:{}{}",
+            target.scheme, target.host, target.port, path
+        )
+    };
+
+    let client = Client::new();
+    let proxy_response = match client
+        .get(target_url)
+        .headers(req.headers().clone())
+        .send()
+        .await
+    {
+        Ok(value) => value,
+        Err(err) => {
+            eprintln!("Failed to send HTTP request: {}", err);
+            let mut error_response = Response::new(hyper::Body::empty());
+            *error_response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+            return Ok(error_response);
+        }
+    };
+    let status = proxy_response.status();
+    let headers = proxy_response.headers().clone();
+
+    let body = match proxy_response.bytes().await {
+        Ok(value) => value,
+        Err(err) => {
+            eprintln!("Failed to read HTTP response body: {}", err);
+            let mut error_response = Response::new(hyper::Body::empty());
+            *error_response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+            return Ok(error_response);
+        }
+    };
+
+    let mut response = Response::new(hyper::body::Body::from(body));
+    *response.status_mut() = status;
+    *response.headers_mut() = headers;
+
+    Ok(response)
 }

--- a/src/servers/http.rs
+++ b/src/servers/http.rs
@@ -1,0 +1,43 @@
+use crate::{constants::HTTP_PORT, show_error};
+use hyper::body::Body;
+use hyper::service::service_fn;
+use hyper::Response;
+use hyper::{server::conn::Http, Request};
+use std::convert::Infallible;
+use std::{net::Ipv4Addr, process::exit};
+use tokio::net::TcpListener;
+
+pub async fn start_server() {
+    // Initializing the underlying TCP listener
+    let listener = match TcpListener::bind((Ipv4Addr::UNSPECIFIED, HTTP_PORT)).await {
+        Ok(value) => value,
+        Err(err) => {
+            let text = format!("Failed to start http: {}", err);
+            show_error("Failed to start", &text);
+            exit(1);
+        }
+    };
+
+    // Accept incoming connections
+    loop {
+        let (stream, _) = match listener.accept().await {
+            Ok(value) => value,
+            Err(_) => break,
+        };
+
+        tokio::task::spawn(async move {
+            if let Err(err) = Http::new()
+                .serve_connection(stream, service_fn(hello))
+                .await
+            {
+                println!("Error serving connection: {:?}", err);
+            }
+        });
+    }
+}
+
+// An async function that consumes a request, does nothing with it and returns a
+// response.
+async fn hello(req: Request<hyper::body::Body>) -> Result<Response<Body>, Infallible> {
+    Ok(Response::new(req.into_body()))
+}

--- a/src/servers/main.rs
+++ b/src/servers/main.rs
@@ -40,6 +40,9 @@ const HEADER_SCHEME: &str = "X-Pocket-Relay-Scheme";
 const HEADER_PORT: &str = "X-Pocket-Relay-Port";
 /// Header for the Pocket Relay connection host used by the client
 const HEADER_HOST: &str = "X-Pocket-Relay-Host";
+/// Header to tell the server to use local HTTP
+const HEADER_LOCAL_HTTP: &str = "X-Pocket-Relay-Local-Http";
+
 /// Endpoint for upgrading the server connection
 const UPGRADE_ENDPOINT: &str = "/api/server/upgrade";
 
@@ -72,6 +75,9 @@ async fn handle_blaze(mut client: TcpStream) {
     if let Ok(host_value) = HeaderValue::from_str(&target.host) {
         headers.insert(HEADER_HOST, host_value);
     }
+
+    // Append use local http header
+    headers.insert(HEADER_LOCAL_HTTP, HeaderValue::from_static("true"));
 
     // Create the request
     let request = Client::new().get(url).headers(headers).send();

--- a/src/servers/mod.rs
+++ b/src/servers/mod.rs
@@ -1,5 +1,6 @@
 use tokio::join;
 
+pub mod http;
 pub mod main;
 pub mod qos;
 pub mod redirector;
@@ -11,6 +12,7 @@ pub async fn start() {
         main::start_server(),
         qos::start_server(),
         redirector::start_server(),
-        telemetry::start_server()
+        telemetry::start_server(),
+        http::start_server()
     );
 }

--- a/src/ui/iced.rs
+++ b/src/ui/iced.rs
@@ -7,8 +7,8 @@ use iced::{
     executor,
     theme::Palette,
     widget::{
-        button, checkbox, column, container, row, text, text_input, Button, Column, Row, Text,
-        TextInput,
+        button, checkbox, column, container, row, scrollable, scrollable::Properties, text,
+        text_input, Button, Column, Row, Text, TextInput,
     },
     window::{self, icon},
     Application, Color, Command, Length, Settings, Theme,
@@ -178,6 +178,9 @@ impl Application for App {
             .style(Palette::DARK.success),
             LookupState::Error(err) => text(err).style(Palette::DARK.danger),
         };
+
+        let status_text =
+            scrollable(status_text).horizontal_scroll(Properties::new().width(2).scroller_width(2));
 
         let target_row: Row<_> = row![target_input, target_button].spacing(SPACING);
 


### PR DESCRIPTION
## Description

> **Info**
> This feature requires a server running v0.5.7 in order for this to be applied

Implements client side HTTP proxying from #11 which allows support for using reverse proxies (See #11 for the reason why reverse proxies didn't work properly with game HTTP requests)  in-front of the Pocket Relay server. The server side portion of this will be included in release v0.5.7 

## Changes
- Added local HTTP proxy server
- Bumped version number for client release 

## Related Issue
- Closes #11 