### PR TITLE
Sub directory support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2494,7 +2494,7 @@ dependencies = [
 
 [[package]]
 name = "pocket-relay-client"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "blaze-ssl-async",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2515,6 +2515,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
+ "url",
  "winres",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ futures = "0.3"
 thiserror = "1"
 semver = { version = "1", features = ["serde"] }
 hyper = { version = "0.14", features = ["server", "http1", "tcp", "runtime"] }
+url = "2.4.1"
 
 log = "0.4"
 env_logger = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pocket-relay-client"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 build = "build.rs"
 license = "MIT"

--- a/src/servers/http.rs
+++ b/src/servers/http.rs
@@ -66,7 +66,8 @@ async fn proxy_http(req: Request<Body>, http_client: Client) -> Result<Response<
             }
         };
 
-        debug!("{}", path);
+        // Remove the leading / to make the path relative
+        let path = path.strip_prefix('/').unwrap_or(path);
 
         match target.url.join(path) {
             Ok(value) => value,

--- a/src/servers/http.rs
+++ b/src/servers/http.rs
@@ -5,7 +5,7 @@ use hyper::body::Body;
 use hyper::service::service_fn;
 use hyper::{server::conn::Http, Request};
 use hyper::{Response, StatusCode};
-use log::error;
+use log::{debug, error};
 use reqwest::Client;
 use std::convert::Infallible;
 use std::{net::Ipv4Addr, process::exit};
@@ -66,10 +66,17 @@ async fn proxy_http(req: Request<Body>, http_client: Client) -> Result<Response<
             }
         };
 
-        format!(
-            "{}://{}:{}{}",
-            target.scheme, target.host, target.port, path
-        )
+        debug!("{}", path);
+
+        match target.url.join(path) {
+            Ok(value) => value,
+            Err(_) => {
+                // Failed to create a path
+                let mut error_response = Response::default();
+                *error_response.status_mut() = StatusCode::SERVICE_UNAVAILABLE;
+                return Ok(error_response);
+            }
+        }
     };
 
     let response = match proxy_request(http_client, target_url).await {
@@ -90,7 +97,7 @@ async fn proxy_http(req: Request<Body>, http_client: Client) -> Result<Response<
 /// a response on success or providing an error.
 async fn proxy_request(
     http_client: Client,
-    target_url: String,
+    target_url: url::Url,
 ) -> Result<Response<Body>, reqwest::Error> {
     let response = http_client.get(target_url).send().await?;
 

--- a/src/servers/main.rs
+++ b/src/servers/main.rs
@@ -50,7 +50,7 @@ const LEGACY_HEADER_HOST: &str = "x-pocket-relay-host";
 const HEADER_LOCAL_HTTP: &str = "x-pocket-relay-local-http";
 
 /// Endpoint for upgrading the server connection
-const UPGRADE_ENDPOINT: &str = "/api/server/upgrade";
+const UPGRADE_ENDPOINT: &str = "api/server/upgrade";
 
 async fn handle_blaze(mut client: TcpStream, http_client: Client) {
     let url = match &*TARGET.read().await {

--- a/src/servers/main.rs
+++ b/src/servers/main.rs
@@ -55,10 +55,11 @@ const UPGRADE_ENDPOINT: &str = "/api/server/upgrade";
 async fn handle_blaze(mut client: TcpStream, http_client: Client) {
     let url = match &*TARGET.read().await {
         // Create the upgrade URL
-        Some(target) => format!(
-            "{}://{}:{}{}",
-            target.scheme, target.host, target.port, UPGRADE_ENDPOINT
-        ),
+        Some(target) => target
+            .url
+            .join(UPGRADE_ENDPOINT)
+            .expect("Failed to create update endpoint URL"),
+
         None => return,
     };
 

--- a/src/servers/telemetry.rs
+++ b/src/servers/telemetry.rs
@@ -8,7 +8,7 @@ use tokio::{
 };
 
 /// Server API endpoint to send telemetry data to
-const TELEMETRY_ENDPOINT: &str = "/api/server/telemetry";
+const TELEMETRY_ENDPOINT: &str = "api/server/telemetry";
 
 pub async fn start_server(http_client: Client) {
     // Initializing the underlying TCP listener

--- a/src/servers/telemetry.rs
+++ b/src/servers/telemetry.rs
@@ -36,16 +36,15 @@ pub async fn start_server(http_client: Client) {
                 None => return,
             };
 
-            // Create the telemetry URL
-            let url = format!(
-                "{}://{}:{}{}",
-                target.scheme, target.host, target.port, TELEMETRY_ENDPOINT
-            );
+            let url = target
+                .url
+                .join(TELEMETRY_ENDPOINT)
+                .expect("Failed to create telemetry endpoint");
 
             let mut stream = stream;
             while let Ok(message) = read_message(&mut stream).await {
                 // TODO: Batch these telemetry messages and send them to the server
-                let _ = http_client.post(&url).json(&message).send().await;
+                let _ = http_client.post(url.clone()).json(&message).send().await;
             }
         });
     }

--- a/src/ui/iced.rs
+++ b/src/ui/iced.rs
@@ -157,7 +157,9 @@ impl Application for App {
             LookupState::Loading => text("Connecting...").style(YELLOW_TEXT),
             LookupState::Success(lookup_data) => text(format!(
                 "Connected: {} {} version v{}",
-                lookup_data.scheme, lookup_data.host, lookup_data.version
+                lookup_data.url.scheme(),
+                lookup_data.url.authority(),
+                lookup_data.version
             ))
             .style(Palette::DARK.success),
             LookupState::Error => text("Failed to connect").style(Palette::DARK.danger),

--- a/src/ui/native.rs
+++ b/src/ui/native.rs
@@ -130,7 +130,9 @@ impl App {
             Ok(result) => {
                 let text = format!(
                     "Connected: {} {} version v{}",
-                    result.scheme, result.host, result.version
+                    result.url.scheme(),
+                    result.url.authority(),
+                    result.version
                 );
                 self.connection_label.set_text(&text)
             }


### PR DESCRIPTION
## Description
Added support for servers running on nginx that have a non root url path, an example nginx configuration for that would be something like the following:
![image](https://github.com/PocketRelay/Client/assets/33708767/d8938924-3712-48b9-bd69-52841be1ebdb)
Which can now be used in the client like so:
![image](https://github.com/PocketRelay/Client/assets/33708767/715ba017-4a1b-4e41-9e0f-0cbbd1f880bd)

This also technically adds support for things like sticking authentication in the url:
![image](https://github.com/PocketRelay/Client/assets/33708767/2523e61a-c692-4111-8aa2-cd71ad23506a)

## Changes
- Client supports servers hosted on subdirectories

## Related Issues
- Closes #21 